### PR TITLE
Add additional screens actions

### DIFF
--- a/combined-schema.json
+++ b/combined-schema.json
@@ -511,6 +511,9 @@
           "$ref": "#/definitions/slices_screen_slice"
         },
         {
+          "$ref": "#/definitions/slices_additional_screens_slice"
+        },
+        {
           "$ref": "#/definitions/slices_assets_prop_slice"
         },
         {
@@ -751,6 +754,21 @@
           "$ref": "#/definitions/ext_debug_schema_json_properties_debug"
         }
       }
+    },
+    "slices_additional_screens_slice": {
+      "title": "Additional screens slice",
+      "type": "object",
+      "properties": {
+        "floorAction": {
+          "type": "string",
+          "description": "Action or instruction for the floor screen"
+        },
+        "rausAction": {
+          "type": "string",
+          "description": "Action or instruction for the raus screen"
+        }
+      },
+      "additionalProperties": true
     },
     "slices_assets_slice": {
       "title": "Assets array slice",

--- a/schemas/profiles/review.schema.json
+++ b/schemas/profiles/review.schema.json
@@ -16,6 +16,7 @@
     { "$ref": "./draft.schema.json" },
     { "$ref": "../slices/meta-scene.slice.schema.json" },
     { "$ref": "../slices/screen.slice.schema.json" },
+    { "$ref": "../slices/additional-screens.slice.schema.json" },
     { "$ref": "../slices/assets.prop.slice.json" },
 
 

--- a/schemas/slices/additional-screens.slice.schema.json
+++ b/schemas/slices/additional-screens.slice.schema.json
@@ -1,0 +1,16 @@
+{
+  "$id": "immerschema/schemas/slices/additional-screens.slice.schema.json",
+  "title": "Additional screens slice",
+  "type": "object",
+  "properties": {
+    "floorAction": {
+      "type": "string",
+      "description": "Action or instruction for the floor screen"
+    },
+    "rausAction": {
+      "type": "string",
+      "description": "Action or instruction for the raus screen"
+    }
+  },
+  "additionalProperties": true
+}

--- a/scripts/test_runner.js
+++ b/scripts/test_runner.js
@@ -82,6 +82,7 @@ function setupAjv() {
     'schemas/slices/voice.slice.schema.json',
     'schemas/slices/meta-scene.slice.schema.json',
     'schemas/slices/screen.slice.schema.json',
+    'schemas/slices/additional-screens.slice.schema.json',
     'schemas/slices/assets.slice.schema.json',
     'schemas/slices/description.slice.schema.json',
     'schemas/slices/workload.slice.json',


### PR DESCRIPTION
## Summary
- replace additional screens enum with text fields
- include `floorAction` and `rausAction` in additional screens slice
- update combined schema
- remove unused enum from test runner

## Testing
- `node combine-schemas.cjs`
- `npm test` *(fails: Cannot find package 'ajv' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685183db64d0832da5aed57046e44d9d